### PR TITLE
prepare to publish 0.2.1-dev.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# 0.2.1
+# 0.2.1-dev.0
+- add dev suffix because this package uses Dart SDK **`dev`**.
 - add getter to board as radix16 String
 
 # 0.2.0-alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.1
+- add getter to board as radix16 String
+
 # 0.2.0-alpha
 publish alpha release
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # libedax4dart
+[![dart-channel](https://img.shields.io/badge/Dart-dev-64B5F6.svg?logo=dart)](https://dart.dev/get-dart#release-channels)
+
 dart wrapper for [libedax](https://github.com/lavox/edax-reversi/tree/libedax).  
 With using libedax4dart, you can execute functions equivalent to [edax](https://sensuikan1973.github.io/edax-reversi/) commands.
 
@@ -26,7 +28,6 @@ With using libedax4dart, you can execute functions equivalent to [edax](https://
 ---
 
 ## Development
-[![dart-channel](https://img.shields.io/badge/Dart-dev-64B5F6.svg?logo=dart)](https://dart.dev/get-dart#release-channels)  
 ![Dart CI](https://github.com/sensuikan1973/libedax4dart/workflows/Dart%20CI/badge.svg)
 ![Integration Test](https://github.com/sensuikan1973/libedax4dart/workflows/Integration%20Test/badge.svg)
 [![codecov](https://codecov.io/gh/sensuikan1973/libedax4dart/branch/main/graph/badge.svg?token=LdDfCMnDhz)](https://codecov.io/gh/sensuikan1973/libedax4dart)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -105,7 +105,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.0-alpha"
+    version: "0.2.1"
   meta:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 # See: https://dart.dev/tools/pub/publishing
 
 name: libedax4dart
-version: 0.2.0-alpha
-description: dart wrapper for libedax
+version: 0.2.1
+description: dart wrapper for libedax. With using libedax4dart, you can execute functions equivalent to edax.
 homepage: https://github.com/sensuikan1973/libedax4dart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 # See: https://dart.dev/tools/pub/publishing
 
 name: libedax4dart
-version: 0.2.1
+version: 0.2.1-dev.0
 description: dart wrapper for libedax. With using libedax4dart, you can execute functions equivalent to edax.
 homepage: https://github.com/sensuikan1973/libedax4dart
 


### PR DESCRIPTION
`dev` SDK を使う場合、Dart pub.dev が完全に死ぬ(pub.dev は SDK beta より先のものを対象外としているため)。
そのため、異様に Score が低くなるのが悲しい。

ただ `beta` SDK でも動くようにするのは結構キツい。ffi の anottation が仕様違うからなあ。
具体的には、beta にすると、各種 struct 定義について以下のエラーで死ぬ。
```sh
"Field '#name' requires exactly one annotation to declare its C++ type, which cannot be Void. dart:ffi Structs cannot have regular Dart fields."
```