### PR TITLE
coordinate deps

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -182,7 +182,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.12"
+    version: "1.4.13"
   package_config:
     dependency: transitive
     description:
@@ -238,21 +238,21 @@ packages:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9+1"
+    version: "0.2.9+2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "0.2.4"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -308,7 +308,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0-nullsafety.16"
+    version: "1.16.0-nullsafety.17"
   test_api:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,11 +9,11 @@ environment:
   sdk: '>=2.12.0-224.0.dev <3.0.0' # See: https://dart.dev/null-safety#enable-null-safety
 
 dependencies:
-  ffi: ^0.2.0-nullsafety.1
-  meta: ^1.3.0-nullsafety.6
+  ffi: '>=0.1.3 <0.3.0'
+  meta: '>=1.2.4 <1.4.0'
 
 dev_dependencies:
-  analyzer: ^0.41.1
+  analyzer: ^0.41.2
   coverage: ^0.15.1 # See: https://github.com/dart-lang/test/issues/1265
   pedantic_sensuikan1973: any
   test: ^1.16.0-nullsafety.16


### PR DESCRIPTION
libedax を使う app 側が null safety 周りの制約に対して柔軟に立ち回れるよう、制約を緩めた