### PR TITLE
bundle coverage reports on multiple platform

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -83,8 +83,10 @@ jobs:
       - name: coverage
         run: dart run coverage:format_coverage --lcov --packages=.packages --in coverage --out lcov.info
       - uses: codecov/codecov-action@v3
-        with:
-          file: lcov.info
+        with: # ref: https://github.com/codecov/codecov-action/blob/v3.1.0/.github/workflows/main.yml
+          files: lcov.info
+          flags: unit_test,${{ matrix.os }}
+          fail_ci_if_error: true
 
       - name: run pana to chceck package score before publish
         if: runner.os == 'Linux'


### PR DESCRIPTION
I want to remove the randomness of coverage report.
It's because coverage report is created by one platform test result which finished lastly.
See: https://github.com/codecov/codecov-action/blob/v3.1.0/.github/workflows/main.yml