### PR TITLE
Update pub_dev_publish.yaml

### DIFF
--- a/.github/workflows/pub_dev_publish.yaml
+++ b/.github/workflows/pub_dev_publish.yaml
@@ -9,4 +9,6 @@ on:
 
 jobs:
   publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
```
The workflow is not valid. .github/workflows/pub_dev_publish.yaml (Line: 11, Col: 3): Error calling workflow 'dart-lang/setup-dart/.github/workflows/publish.yml@v1'. The nested job 'Publish to pub.dev' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```