### PR TITLE
use `DynamicLibrary.close()` on `closeDll`

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -185,4 +185,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.5 <4.0.0"
+  dart: ">=3.1.0 <4.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ name: libedax4dart_example
 publish_to: none
 
 environment:
-  sdk: ">=3.0.5 <4.0.0"
+  sdk: ">=3.1.0 <4.0.0"
 
 dependencies:
   ffi: ^2.0.2

--- a/lib/src/libedax.dart
+++ b/lib/src/libedax.dart
@@ -57,11 +57,6 @@ class LibEdax {
   @experimental
   void closeDll() => _dylib.close();
 
-  // See: https://github.com/dart-lang/ffi/blob/f3346299c55669cc0db48afae85b8110088bf8da/lib/src/allocation.dart#L8-L11
-  DynamicLibrary get _stdlib => Platform.isWindows
-      ? DynamicLibrary.open('kernel32.dll')
-      : DynamicLibrary.process();
-
   /// Init board.
   void edaxInit() => _bindings.edax_init();
 

--- a/lib/src/libedax.dart
+++ b/lib/src/libedax.dart
@@ -53,12 +53,9 @@ class LibEdax {
 
   /// Close dll.
   ///
-  /// FIXME: this is workaround Function.
-  /// See: https://github.com/dart-lang/sdk/issues/40159
-  ///
   /// After you call this, if you use edax command, you have to recreate [LibEdax] instance.
   @experimental
-  void closeDll() => _dlCloseFunc(_dylib.handle);
+  void closeDll() => _dylib.close();
 
   int Function(Pointer<Void>) get _dlCloseFunc {
     final funcName = Platform.isWindows ? 'FreeLibrary' : 'dlclose';

--- a/lib/src/libedax.dart
+++ b/lib/src/libedax.dart
@@ -57,13 +57,6 @@ class LibEdax {
   @experimental
   void closeDll() => _dylib.close();
 
-  int Function(Pointer<Void>) get _dlCloseFunc {
-    final funcName = Platform.isWindows ? 'FreeLibrary' : 'dlclose';
-    return _stdlib
-        .lookup<NativeFunction<Int32 Function(Pointer<Void>)>>(funcName)
-        .asFunction();
-  }
-
   // See: https://github.com/dart-lang/ffi/blob/f3346299c55669cc0db48afae85b8110088bf8da/lib/src/allocation.dart#L8-L11
   DynamicLibrary get _stdlib => Platform.isWindows
       ? DynamicLibrary.open('kernel32.dll')

--- a/lib/src/libedax.dart
+++ b/lib/src/libedax.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'dart:io';
 
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -570,4 +570,4 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=3.0.5 <4.0.0"
+  dart: ">=3.1.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ issue_tracker: https://github.com/sensuikan1973/libedax4dart/issues
 repository: https://github.com/sensuikan1973/libedax4dart
 
 environment:
-  sdk: '>=3.0.5 <4.0.0' # See: https://dart.dev/null-safety#enable-null-safety
+  sdk: '>=3.1.0 <4.0.0' # See: https://dart.dev/null-safety#enable-null-safety
 
 dependencies:
   ffi: ^2.0.2


### PR DESCRIPTION
See: https://github.com/dart-lang/sdk/issues/40159#issuecomment-1579106203

https://api.flutter.dev/flutter/dart-ffi/DynamicLibrary/close.html